### PR TITLE
[master] BoardConfig: Move NFC chip type to the platform config

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -19,10 +19,6 @@ TARGET_BOOTLOADER_BOARD_NAME := H3113
 # Platform
 PRODUCT_PLATFORM := nile
 
-# NFC
-NXP_CHIP_TYPE := PN553
-NXP_CHIP_FW_TYPE := PN553
-
 BOARD_KERNEL_CMDLINE += androidboot.hardware=pioneer
 
 # Partition information


### PR DESCRIPTION
Discovery and Pioneer devices have the same PN553 chip
so move NXP_CHIP_TYPE to the Nile platform repo.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>